### PR TITLE
nprint-install bootstrapping command

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,8 @@ As needed, consult your package manager or [python.org](https://python.org/).
 
 Depending on your situation, consider [pyenv](https://github.com/pyenv/pyenv) for easy installation and management of arbitrary versions of Python.
 
+nprintML further requires nPrint (see below).
+
 ### Installation
 
 nprintML itself is available for download from the [Python Package Index (PyPI)](https://pypi.org/) and via `pip`:
@@ -27,7 +29,17 @@ This downloads, builds and installs the `nprintml` console command. If you're ha
 
 That said, installation of this command via a tool such as [pipx](https://pipxproject.github.io/pipx/) is strongly encouraged. pipx will ensure that nprintML is installed into its own virtual environment, such that its third-party libraries do not conflict with any others installed on your system.
 
-(Note that nprint and nprintML are unrelated to the PyPI distribution named "nprint.")
+(Note that nPrint and nprintML are unrelated to the PyPI distribution named "nprint.")
+
+### Post-installation
+
+nprintML depends on the nPrint command, which may be installed separately, (with reference to the [nPrint documentation](https://github.com/nprint/nprint/wiki/2.-Installation)).
+
+For quick-and-easy satisfaction of this requirement, nprintML supplies the bootstrapping command `nprint-install`, which is made available to your environment with nprintML installed. This command will inspect its execution environment and attempt to retrieve, compile and install nPrint with the most appropriate defaults:
+
+    nprint-install
+
+nPrint may thereby be installed system-globally, to the user environment, to the (virtual) environment to which nprintML was installed, or to a specified path prefix. Consult the command's `--help` for more information.
 
 
 ## Using It

--- a/setup.cfg
+++ b/setup.cfg
@@ -16,7 +16,12 @@ envlist = py36, py37, py38, lint
 minversion = 3.20.1
 
 [testenv:py{36,37,38}]
-commands = python -m unittest -vb {posargs}
+allowlist_externals = sh
+commands_pre =
+  # install nprint into environ via bootstrap & check that it worked
+  sh -c 'test "$(which nprint)" = "{envbindir}/nprint" || nprint-install -s && test "$(which nprint)" = "{envbindir}/nprint"'
+commands =
+  python -m unittest -vb {posargs}
 
 [testenv:lint]
 deps = flake8==3.8.3

--- a/setup.py
+++ b/setup.py
@@ -61,6 +61,9 @@ setup(name='nprintml',
       packages=find_packages('src'),
       package_dir={'': 'src'},
       entry_points={
-          'console_scripts': ['nprintml=nprintml.cli:execute'],
+          'console_scripts': [
+              'nprintml=nprintml.cli:execute',
+              'nprint-install=nprintml.net.bootstrap:execute',
+            ],
       },
 )

--- a/src/nprintml/__init__.py
+++ b/src/nprintml/__init__.py
@@ -1,1 +1,3 @@
 __version__ = '0.0.0'
+
+__nprint_version__ = '1.1.1'

--- a/src/nprintml/cli.py
+++ b/src/nprintml/cli.py
@@ -1,9 +1,11 @@
+"""nprintML command-line interface entry-point"""
 import argparse
 
 # import argparse_formatter  # FIXME
 
 
 def execute(argv=None, **parser_kwargs):
+    """Execute the nprintml CLI command."""
     parser = argparse.ArgumentParser(
         description='DESCRIPTION GOES HERE',
 

--- a/src/nprintml/net/bootstrap.py
+++ b/src/nprintml/net/bootstrap.py
@@ -1,0 +1,266 @@
+"""nPrint installation bootstrapping command"""
+import argparse
+import enum
+import os
+import pathlib
+import re
+import shutil
+import subprocess
+import sys
+import tarfile
+import tempfile
+import urllib.request
+
+import argparse_formatter
+
+import nprintml
+
+
+NPRINT_RELEASE_NAME = f'nprint-{nprintml.__nprint_version__}'
+
+NPRINT_ARCHIVE_NAME = f'{NPRINT_RELEASE_NAME}.tar.gz'
+
+NPRINT_ARCHIVE_URL = (
+    'https://github.com/nprint/nprint/releases/download/'
+    f'v{nprintml.__nprint_version__}/{NPRINT_ARCHIVE_NAME}'
+)
+
+USER_LOCAL_PATH = pathlib.Path.home() / '.local'
+
+PYENV_PATH = os.getenv('PYENV_ROOT') or pathlib.Path.home() / '.pyenv'
+
+BUILD_COMMANDS = (
+    ('sh', 'configure', '--prefix={prefix}'),
+    ('make',),
+    ('make', 'install'),
+)
+
+BUILD_DEPENDENCIES = (
+    'pcap',
+)
+
+
+class PathOption(str, enum.Enum):
+    """system installation path options"""
+
+    system_global = ('system-globally', None)
+    current_user = ('for the current user only', USER_LOCAL_PATH)
+    same_environ = ('into the same environment as nprintML', sys.prefix)
+    user_specified = ('under another arbitrary path', None)
+
+    def __new__(cls, description, target):
+        # we really want to treat these as str (description)
+        # (with attributes set elsewhere)
+        obj = super().__new__(cls, description)
+        obj._value_ = description
+        return obj
+
+    def __init__(self, description, target):
+        self.description = description
+        self.target = target
+
+    @classmethod
+    def get_path_defaults(cls):
+        """Select most appropriate default installation path given
+        system context.
+
+        """
+        # if run as root assume they want to install globally
+        if os.geteuid() == 0:
+            return cls.system_global
+
+        # if python's environment prefix is writable --
+        # likely a virtual environment --
+        # default to installing alongside there
+        if os.access(sys.prefix, os.W_OK):
+            return cls.same_environ
+
+        # finally -- safest -- default to the user's home path
+        return cls.current_user
+
+    @property
+    def help_text(self):
+        """verbose representation for help text"""
+        help_text = self.description
+        if self.target:
+            help_text += f" ({self.target})"
+        return help_text
+
+
+def execute(argv=None, **parser_kwargs):
+    """Execute the nPrint-installation CLI command."""
+    path_option_default = PathOption.get_path_defaults()
+
+    parser = argparse.ArgumentParser(
+        description=(
+            "install nPrint\n\n"
+
+            "installation path:\n\n"
+
+            "  Commands such as nPrint are frequently installed \"globally\" to a system – "
+            "often under /usr/local/.\n\n"
+
+            "  Specify any of the following options to install nPrint either:\n\n"
+
+            + '\n'.join(f'    • {option}' for option in PathOption) + "\n\n" +
+
+            "  For the current invocation and without options nPrint will be installed "
+            f"by default {path_option_default.help_text}."
+        ),
+        formatter_class=argparse_formatter.FlexiFormatter,
+        **parser_kwargs,
+    )
+
+    installation_path = parser.add_mutually_exclusive_group()
+    installation_path.add_argument(
+        '-p', '--prefix',
+        metavar='PATH',
+        help="specify an arbitrary installation path prefix "
+             "(generally an alternative to /usr/local/)",
+    )
+    installation_path.add_argument(
+        '-g', '--global',
+        action='store_const',
+        const=None,
+        dest='prefix',
+        help="install system-globally (generally under /usr/local/ – may require sudo)",
+    )
+    installation_path.add_argument(
+        '-u', '--user',
+        action='store_const',
+        const=PathOption.current_user.target,
+        dest='prefix',
+        help=f"install for current user only (under {PathOption.current_user.target})",
+    )
+    installation_path.add_argument(
+        '-s', '--same',
+        action='store_const',
+        const=PathOption.same_environ.target,
+        dest='prefix',
+        help=f"install into same environment as nprintML (under {PathOption.same_environ.target})",
+    )
+    installation_path.set_defaults(
+        prefix=path_option_default.target,
+    )
+
+    args = parser.parse_args(argv)
+
+    (build_commands, missing_commands) = get_build_commands(prefix=args.prefix)
+
+    if missing_commands:
+        parser.error('missing requirement(s): ' + ', '.join(missing_commands))
+
+    missing_dependencies = get_missing_dependencies()
+
+    if missing_dependencies:
+        parser.error('missing dependenc(ies): ' + ', '.join(missing_dependencies) +
+                     '\nconsult: https://github.com/nprint/nprint/wiki/2.-Installation')
+
+    execute_bootstrap(build_commands)
+
+    # check for pyenv tip
+    try:
+        pathlib.Path(args.prefix).relative_to(PYENV_PATH)
+    except ValueError:
+        # no apparent association with pyenv
+        pass
+    else:
+        print('\nℹ nPrint appears to have been installed into a Pyenv environment – '
+              'rehash may be required before it is available for use:\n\n'
+              '\tpyenv rehash\n')
+
+
+def get_build_commands(**kwargs):
+    """Check for system availability of and return the system commands
+    required to build nPrint.
+
+    Command options may be populated via keyword argument. Unpopulated
+    or null options are discarded.
+
+    """
+    context = {key: value for (key, value) in kwargs.items()
+               if value is not None}
+
+    def generate_command_args(args):
+        for arg in args:
+            try:
+                yield arg.format_map(context)
+            except KeyError:
+                continue
+
+    build_commands = [
+        (shutil.which(cmd),) + tuple(generate_command_args(args))
+        for (cmd, *args) in BUILD_COMMANDS
+    ]
+
+    missing_commands = {
+        cmd for (found, cmd) in zip(
+            (command[0] for command in build_commands),
+            (command[0] for command in BUILD_COMMANDS),
+        )
+        if not found
+    }
+
+    return (
+        build_commands,
+        missing_commands,
+    )
+
+
+def get_missing_dependencies():
+    """Look up dependencies & return those which could not be located."""
+    whereis = shutil.which('whereis')
+
+    if whereis is None:
+        print('[warn] whereis command unavailable – '
+              'cannot execute check for build dependencies',
+              file=sys.stderr)
+
+        return []
+
+    dependency_results = (subprocess.check_output([whereis, lib]) for lib in BUILD_DEPENDENCIES)
+
+    dependency_locations = (re.sub(rf'^{lib}: ?', '', result.decode())
+                            for (lib, result) in zip(BUILD_DEPENDENCIES, dependency_results))
+
+    try:
+        return [
+            lib for (lib, location) in zip(BUILD_DEPENDENCIES, dependency_locations)
+            if not location.strip()
+        ]
+    except subprocess.CalledProcessError:
+        print('[warn] whereis command failed – '
+              'cannot execute check for build dependencies',
+              file=sys.stderr)
+
+        return []
+
+
+def execute_bootstrap(commands):
+    """Retrieve nPrint release & execute given installation commands."""
+    with tempfile.TemporaryDirectory(prefix=f'{__name__}.') as tempdir:
+        temp_path = pathlib.Path(tempdir)
+        release_path = temp_path / NPRINT_RELEASE_NAME
+        archive_path = temp_path / NPRINT_ARCHIVE_NAME
+
+        urllib.request.urlretrieve(NPRINT_ARCHIVE_URL, archive_path)
+
+        with tarfile.open(archive_path) as release_archive:
+            release_archive.extractall(tempdir)
+
+        for command in commands:
+            print('→', *command, end='\n\n')
+
+            try:
+                subprocess.run(
+                    command,
+                    cwd=release_path,
+                    check=True,
+                )
+            except subprocess.CalledProcessError as exc:
+                print('\n✕ failed')
+                sys.exit(exc.returncode)
+            else:
+                print()
+
+    print('✓ success')


### PR DESCRIPTION
to help users ensure that nprint is installed and available

(it's useful for devops as well 😉)

resolves #7