### PR TITLE
command alias for `nprintml`: `nml`

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,9 +44,13 @@ nPrint may thereby be installed system-globally, to the user environment, to the
 
 ## Using It
 
-nprintML supplies the top-level shell command `nprintml`:
+nprintML supplies the top-level shell command `nprintml` &ndash;
 
     nprintml ...
+
+&ndash; as well as its terse alias `nml` &ndash;
+
+    nml ...
 
 In case of command path ambiguity and in support of debugging, the `nprintml` command is identically available through its Python module (no different from `pip` above):
 

--- a/setup.py
+++ b/setup.py
@@ -62,6 +62,7 @@ setup(name='nprintml',
       package_dir={'': 'src'},
       entry_points={
           'console_scripts': [
+              'nml=nprintml.cli:execute',
               'nprintml=nprintml.cli:execute',
               'nprint-install=nprintml.net.bootstrap:execute',
             ],


### PR DESCRIPTION
resolves #6