### PR TITLE
distro release

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ nprintML further requires nPrint (see below).
 
 ### Installation
 
-nprintML itself is available for download from the [Python Package Index (PyPI)](https://pypi.org/) and via `pip`:
+nprintML itself is available for download from the [Python Package Index (PyPI)](https://pypi.org/project/nprintml/) and via `pip`:
 
     python -m pip install nprintml
 

--- a/manage.py
+++ b/manage.py
@@ -3,6 +3,9 @@
 This module populates ``manage`` sub-commands.
 
 """
+import copy
+import re
+
 from argparse import REMAINDER
 
 import argparse_formatter
@@ -130,8 +133,8 @@ class Release(Local):
         )
 
     def prepare(self, args):
-        if args.versions:
-            target = [f'dist/{self.distribution_name}-{version}*' for version in args.versions]
+        if args.version:
+            target = [f'dist/{self.distribution_name}-{version}*' for version in args.version]
         else:
             target = [f'dist/{self.distribution_name}-*']
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -16,6 +16,17 @@ envlist = py36, py37, py38, lint
 minversion = 3.20.1
 
 [testenv:py{36,37,38}]
+# Numpy required to build Autogluon under py36-7 due to mispackaging in its own dependency, ConfigSpace.
+# Autogluon @ fa349db5e75a18cd3af7d9d3f1064eb34e92aca1 upgrades to a fixed ConfigSpace; however, this
+# revision has not yet been released to PyPI, and nprintML cannot be released to PyPI with non-PyPI dependencies.
+# As such, for the time being, numpy will be presumed in building nprintML here, and nprintML released as-is
+# with the latest release of Autogluon.
+#
+# The Autogluon requirement should be upgraded as soon as possible, and the below numpy dependency removed.
+#
+# See nprintML @ 32ce3a2 for more information.
+#
+deps = numpy
 allowlist_externals = sh
 commands_pre =
   # install nprint into environ via bootstrap & check that it worked

--- a/setup.cfg
+++ b/setup.cfg
@@ -2,7 +2,7 @@
 commit = True
 tag = True
 tag_name = {new_version}
-current_version = 0.0.0
+current_version = 0.0.1
 
 [bumpversion:file:setup.py]
 
@@ -16,23 +16,12 @@ envlist = py36, py37, py38, lint
 minversion = 3.20.1
 
 [testenv:py{36,37,38}]
-# Numpy required to build Autogluon under py36-7 due to mispackaging in its own dependency, ConfigSpace.
-# Autogluon @ fa349db5e75a18cd3af7d9d3f1064eb34e92aca1 upgrades to a fixed ConfigSpace; however, this
-# revision has not yet been released to PyPI, and nprintML cannot be released to PyPI with non-PyPI dependencies.
-# As such, for the time being, numpy will be presumed in building nprintML here, and nprintML released as-is
-# with the latest release of Autogluon.
-#
-# The Autogluon requirement should be upgraded as soon as possible, and the below numpy dependency removed.
-#
-# See nprintML @ 32ce3a2 for more information.
-#
 deps = numpy
 allowlist_externals = sh
-commands_pre =
-  # install nprint into environ via bootstrap & check that it worked
-  sh -c 'test "$(which nprint)" = "{envbindir}/nprint" || nprint-install -s && test "$(which nprint)" = "{envbindir}/nprint"'
-commands =
-  python -m unittest -vb {posargs}
+commands_pre = 
+	sh -c 'test "$(which nprint)" = "{envbindir}/nprint" || nprint-install -s && test "$(which nprint)" = "{envbindir}/nprint"'
+commands = 
+	python -m unittest -vb {posargs}
 
 [testenv:lint]
 deps = flake8==3.8.3

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,31 @@ INSTALL_REQUIRES = [
     # for cuda, e.g.: mxnet_cu101 < 2.0.0
     'mxnet < 2.0.0',
 
-    'autogluon ~= 0.0.14',
+    # The latest autogluon release (0.0.14) is not directly installable -- nor installable as a
+    # requirement here -- due to mispackaging in its own dependency, ConfigSpace.
+    #
+    # (autogluon is installable according to its own documentation only because mxnet is then
+    # explicitly installed first, which implicitly resolves ConfigSpace's misconfiguration.)
+    #
+    # ConfigSpace was fixed in its 0.4.15, and autogluon has upgraded its requirement; but, it has
+    # not yet been released with this upgrade.
+    #
+    # As such a source revision of autogluon is here required and must be built; this further
+    # requires wheel.
+    #
+    # As soon as autogluon resolves this in a release, this requirement should be ugraded to that
+    # release; (and, wheel should then be removed from this listing).
+    #
+    # The old autogluon requirement:
+    #
+    # 'autogluon ~= 0.0.14',
+    #
+    # The revision with the fix: fa349db5e75a18cd3af7d9d3f1064eb34e92aca1:
+    'autogluon @ https://github.com/awslabs/autogluon/archive/fa349db.zip#subdirectory=autogluon',
+    #
+    # wheel (only required for above):
+    'wheel==0.35.1',
+
     'scikit-learn ~= 0.23.2',
 
     'matplotlib ~= 3.3.3',

--- a/setup.py
+++ b/setup.py
@@ -15,31 +15,7 @@ INSTALL_REQUIRES = [
     # for cuda, e.g.: mxnet_cu101 < 2.0.0
     'mxnet < 2.0.0',
 
-    # The latest autogluon release (0.0.14) is not directly installable -- nor installable as a
-    # requirement here -- due to mispackaging in its own dependency, ConfigSpace.
-    #
-    # (autogluon is installable according to its own documentation only because mxnet is then
-    # explicitly installed first, which implicitly resolves ConfigSpace's misconfiguration.)
-    #
-    # ConfigSpace was fixed in its 0.4.15, and autogluon has upgraded its requirement; but, it has
-    # not yet been released with this upgrade.
-    #
-    # As such a source revision of autogluon is here required and must be built; this further
-    # requires wheel.
-    #
-    # As soon as autogluon resolves this in a release, this requirement should be ugraded to that
-    # release; (and, wheel should then be removed from this listing).
-    #
-    # The old autogluon requirement:
-    #
-    # 'autogluon ~= 0.0.14',
-    #
-    # The revision with the fix: fa349db5e75a18cd3af7d9d3f1064eb34e92aca1:
-    'autogluon @ https://github.com/awslabs/autogluon/archive/fa349db.zip#subdirectory=autogluon',
-    #
-    # wheel (only required for above):
-    'wheel==0.35.1',
-
+    'autogluon ~= 0.0.14',
     'scikit-learn ~= 0.23.2',
 
     'matplotlib ~= 3.3.3',

--- a/setup.py
+++ b/setup.py
@@ -15,6 +15,21 @@ INSTALL_REQUIRES = [
     # for cuda, e.g.: mxnet_cu101 < 2.0.0
     'mxnet < 2.0.0',
 
+    # FIXME: Numpy pre-required in build environment to build Autogluon under py36-7 due to
+    # mispackaging in its own dependency, ConfigSpace.
+    #
+    # Autogluon @ fa349db5e75a18cd3af7d9d3f1064eb34e92aca1 upgrades to a fixed ConfigSpace;
+    # however, this revision has not yet been released to PyPI, and nprintML cannot be released to
+    # PyPI with non-PyPI dependencies.
+    #
+    # As such, for the time being, numpy will be presumed in building nprintML, and nprintML
+    # released as-is with the latest release of Autogluon.
+    #
+    # The Autogluon requirement should be upgraded as soon as possible, and the numpy dependency
+    # removed from setup.cfg (tox).
+    #
+    # See nprintML @ 32ce3a2 for more information.
+    #
     'autogluon ~= 0.0.14',
     'scikit-learn ~= 0.23.2',
 

--- a/setup.py
+++ b/setup.py
@@ -40,7 +40,7 @@ EXTRAS_REQUIRE = {
 
 
 setup(name='nprintml',
-      version='0.0.0',
+      version='0.0.1',
       description='Fully automated traffic analysis with nPrint',
       long_description=README_PATH.read_text(),
       long_description_content_type="text/markdown",

--- a/setup.py
+++ b/setup.py
@@ -50,7 +50,7 @@ setup(name='nprintml',
       install_requires=INSTALL_REQUIRES,
       extras_require=EXTRAS_REQUIRE,
       classifiers=[
-          'Development Status :: 1 - Planning',
+          'Development Status :: 2 - Pre-Alpha',
           'Intended Audience :: Developers',
           'Intended Audience :: Education',
           'Intended Audience :: Information Technology',

--- a/src/nprintml/__init__.py
+++ b/src/nprintml/__init__.py
@@ -1,3 +1,3 @@
-__version__ = '0.0.0'
+__version__ = '0.0.1'
 
 __nprint_version__ = '1.1.1'

--- a/src/nprintml/learn/automl.py
+++ b/src/nprintml/learn/automl.py
@@ -11,7 +11,7 @@ import itertools
 
 import matplotlib.pyplot as plt
 import seaborn as sns
-from autogluon import TabularPrediction as task
+from autogluon.tabular import TabularPrediction as task
 from sklearn.model_selection import train_test_split
 from sklearn.preprocessing import LabelBinarizer
 from sklearn.metrics import (

--- a/src/nprintml/learn/automl.py
+++ b/src/nprintml/learn/automl.py
@@ -11,7 +11,7 @@ import itertools
 
 import matplotlib.pyplot as plt
 import seaborn as sns
-from autogluon.tabular import TabularPrediction as task
+from autogluon import TabularPrediction as task
 from sklearn.model_selection import train_test_split
 from sklearn.preprocessing import LabelBinarizer
 from sklearn.metrics import (


### PR DESCRIPTION
These changes were required to prepare the library for release as a Python distribution on PyPI.

---

**NOTE**: The use of an autogluon source revision was necessary to get it to install from scratch as a library dependency, (as commented in code). Otherwise, this fails due to undeclared / mismanaged dependencies upstream. However, PyPI will not permit me to upload a package with source dependencies (dependencies outside of PyPI itself).

This may be resolved in a number of ways. I'll leave this version here for now, as it works to make nprintML simply and directly installable in one line – though, outside of PyPI. 

If autogluon weren't going to push a release any time soon, then we might document how to get nprintML installed with the last release, via two `pip install` commands – this isn't a big deal, though it's annoying, (and complicates the `pipx` workflow for really getting it up-and-running quickly).

But for the moment I propose that we get what we have in `main` released to PyPI and not worry yet about the autogluon installation issue – judging by their release history, it seems likely they'll push another one soon.