### PR TITLE
bump autogluon version requirement to fix installation

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -16,7 +16,6 @@ envlist = py36, py37, py38, lint
 minversion = 3.20.1
 
 [testenv:py{36,37,38}]
-deps = numpy
 allowlist_externals = sh
 commands_pre = 
 	sh -c 'test "$(which nprint)" = "{envbindir}/nprint" || nprint-install -s && test "$(which nprint)" = "{envbindir}/nprint"'

--- a/setup.py
+++ b/setup.py
@@ -15,22 +15,7 @@ INSTALL_REQUIRES = [
     # for cuda, e.g.: mxnet_cu101 < 2.0.0
     'mxnet < 2.0.0',
 
-    # FIXME: Numpy pre-required in build environment to build Autogluon under py36-7 due to
-    # mispackaging in its own dependency, ConfigSpace.
-    #
-    # Autogluon @ fa349db5e75a18cd3af7d9d3f1064eb34e92aca1 upgrades to a fixed ConfigSpace;
-    # however, this revision has not yet been released to PyPI, and nprintML cannot be released to
-    # PyPI with non-PyPI dependencies.
-    #
-    # As such, for the time being, numpy will be presumed in building nprintML, and nprintML
-    # released as-is with the latest release of Autogluon.
-    #
-    # The Autogluon requirement should be upgraded as soon as possible, and the numpy dependency
-    # removed from setup.cfg (tox).
-    #
-    # See nprintML @ 32ce3a2 for more information.
-    #
-    'autogluon ~= 0.0.14',
+    'autogluon ~= 0.0.15',
     'scikit-learn ~= 0.23.2',
 
     'matplotlib ~= 3.3.3',


### PR DESCRIPTION
Autogluon v0.0.14 suffered from two separate installation issues:

1. Its dependency, ConfigSpace, presumed the presence of Numpy, and as
such failed the nprintML build in a fresh/isolated environment, (at
least in py36 & py37).

2. Another of its dependencies subsequently released a change which
broke the installation of Autogluon in *all* instances (see
https://github.com/awslabs/autogluon/issues/811).

Autogluon v0.0.15 resolved (2) directly.

nprintML's existing requirement spec for Autogluon (~=) retrieved this
patch without modification. This version bump merely records the
requirement for the patch explicitly.

By happenstance, the release of Autogluon v0.0.15 *also* resolved (1)
for py36 & py37, (most likely through the release of proper pre-built
wheels for these versions). As such, the shim of pre-installing Numpy
into test environments is here removed. And, it is expected that users
of nprintML in these versions of Python will subsequently have no
problem.

Note: the underlying issue behind (1) is likely not resolved, and will
not be until Autogluon @ fa349db5e75a18cd3af7d9d3f1064eb34e92aca1 is
released; (it currently remains unreleased from that project repo's
master branch). However, it is considered acceptable here for this
issue to be resolved through these projects' release processes (*i.e.*
pre-built wheels), and so the issue may be considered resolved, for now.