### PR TITLE
upgrade nPrint requirement v1.1.1 -> v1.1.3

### DIFF
--- a/src/nprintml/__init__.py
+++ b/src/nprintml/__init__.py
@@ -1,3 +1,3 @@
 __version__ = '0.0.3'
 
-__nprint_version__ = '1.1.1'
+__nprint_version__ = '1.1.3'


### PR DESCRIPTION
I noticed that nPrint has put out a couple releases since this requirement was last set.

Good to pull in those improvements.