### PR TITLE
--help stabilization & eager pipeline ordering

### DIFF
--- a/src/nprintml/label/step.py
+++ b/src/nprintml/label/step.py
@@ -27,6 +27,7 @@ class Label(pipeline.Step):
     Returns a `LabelResult`.
 
     """
+    __provides__ = LabelResult
     __requires__ = ('nprint_path',)
 
     def __init__(self, parser):

--- a/src/nprintml/learn/step.py
+++ b/src/nprintml/learn/step.py
@@ -21,6 +21,7 @@ class Learn(pipeline.Step):
     Returns a `LearnResult`.
 
     """
+    __provides__ = LearnResult
     __requires__ = ('features',)
 
     def __init__(self, parser):

--- a/src/nprintml/net/step.py
+++ b/src/nprintml/net/step.py
@@ -26,6 +26,8 @@ class Net(pipeline.Step):
     Returns a `NetResult`.
 
     """
+    __provides__ = NetResult
+
     def __init__(self, parser):
         self.group_parser = parser.add_argument_group(
             "extraction of features from network traffic via nPrint",

--- a/test/test_pipeline.py
+++ b/test/test_pipeline.py
@@ -1,0 +1,36 @@
+"""Tests for the nprintML Pipeline"""
+import argparse
+import unittest
+
+from nprintml import pipeline
+
+import nprintml.net.step
+import nprintml.label.step
+import nprintml.learn.step
+
+
+class TestPipeline(unittest.TestCase):
+
+    def setUp(self):
+        self.parser = argparse.ArgumentParser()
+
+    def test_eager_ordering(self):
+        "pipeline determines step ordering upon inst'n and so extends parser"
+        self.assertEqual(len(self.parser._action_groups), 2)
+
+        pline = pipeline.Pipeline(self.parser)
+
+        self.assertEqual(len(self.parser._action_groups), 5)
+
+        for (defining_word, action_group) in zip(
+            ('network', 'label', 'automl'),
+            self.parser._action_groups[2:],
+        ):
+            self.assertIn(defining_word, action_group.title)
+
+        pipeline_steps = [type(step) for step in pline]
+        self.assertSequenceEqual(pipeline_steps, (
+            nprintml.net.step.Net,
+            nprintml.label.step.Label,
+            nprintml.learn.step.Learn,
+        ))


### PR DESCRIPTION
#### Sort pipeline steps upon instantiation & stabilize ordering of --help groups

The nprintML pipeline previously determined its step order (DAG) lazily,
*i.e.* upon execution. This allowed step definition to be more lax;
however, it caused steps to extend the CLI argument parser in arbitrary
order, resulting in an inconsistent and misordered --help result.

The pipeline is here made an ordered `list` (rather than an unordered
`set`), with its steps instantiated in their DAG/dependency order.

Pipeline execution retains some of its previous results-checking -- as
steps may fail to deliver on their dependencies' requirements -- but is
otherwise simplified, as step order has already been established.

(Moreover, as desired, eager sorting will enable features such as a dry
run.)