### PR TITLE
execute nPrint calls via subprocess pool of size --concurrency

### DIFF
--- a/src/nprintml/cli.py
+++ b/src/nprintml/cli.py
@@ -111,6 +111,16 @@ def build_parser(**parser_kwargs):
         help="print exception tracebacks",
     )
 
+    cpu_available_count = len(os.sched_getaffinity(0))
+    parser.add_argument(
+        '--concurrency',
+        default=cpu_available_count,
+        metavar='INTEGER',
+        type=int,
+        help="maximum number of concurrent processes to use (defaults to number "
+             f"reported by scheduler: {cpu_available_count})",
+    )
+
     output_default = get_default_directory()
     parser.add_argument(
         '-o', '--output',

--- a/src/nprintml/learn/automl.py
+++ b/src/nprintml/learn/automl.py
@@ -57,7 +57,7 @@ class AutoML:
         'best_quality',
     )
 
-    N_THREADS = 1
+    N_THREADS = None
 
     TEST_SIZE = 0.3
 

--- a/src/nprintml/learn/step.py
+++ b/src/nprintml/learn/step.py
@@ -69,11 +69,10 @@ class Learn(pipeline.Step):
         )
         group_parser.add_argument(
             '--threads',
-            default=AutoML.N_THREADS,
             dest='n_threads',
             metavar='INTEGER',
             type=NumericRangeType(int, (0, None)),
-            help=f"number of CPU threads to dedicate to training (default: {AutoML.N_THREADS})",
+            help="number of CPU threads to dedicate to training (default: same as --concurrency)",
         )
 
     def __call__(self, args, results):
@@ -84,7 +83,7 @@ class Learn(pipeline.Step):
             eval_metric=args.eval_metric,
             quality=args.quality,
             time_limits=args.time_limits,
-            n_threads=args.n_threads,
+            n_threads=(args.n_threads or args.concurrency),
             verbosity=args.verbosity,
         )
 

--- a/src/nprintml/net/execute.py
+++ b/src/nprintml/net/execute.py
@@ -24,15 +24,9 @@ def nprint(*args, stdin=None, stdout=None, stderr=None, check=True):
     Returns the resulting `subprocess.CompletedProcess`.
 
     """
-    # ensure we know what we're running via which
-    cmd = shutil.which('nprint')
-
-    if cmd is None:
-        raise NoCommand
-
     try:
         return subprocess.run(
-            (cmd,) + args,
+            _nprint_args(*args),
             stdin=stdin,
             stdout=stdout,
             stderr=stderr,
@@ -40,6 +34,28 @@ def nprint(*args, stdin=None, stdout=None, stderr=None, check=True):
         )
     except subprocess.CalledProcessError as exc:
         raise CommandError from exc
+
+
+def nPrintProcess(*args, stdin=None, stdout=None, stderr=None):
+    """TODO
+
+    """
+    return subprocess.Popen(
+        _nprint_args(*args),
+        stdin=stdin,
+        stdout=stdout,
+        stderr=stderr,
+    )
+
+
+def _nprint_args(*args):
+    # ensure we know what we're running via which
+    cmd = shutil.which('nprint')
+
+    if cmd is None:
+        raise NoCommand
+
+    return (cmd,) + args
 
 
 class nPrintError(Exception):
@@ -57,3 +73,6 @@ class NoCommand(nPrintError):
 nprint.CommandError = CommandError
 nprint.NoCommand = NoCommand
 nprint.PIPE = subprocess.PIPE
+
+nPrintProcess.NoCommand = NoCommand
+nPrintProcess.PIPE = subprocess.PIPE

--- a/src/nprintml/net/execute.py
+++ b/src/nprintml/net/execute.py
@@ -37,7 +37,23 @@ def nprint(*args, stdin=None, stdout=None, stderr=None, check=True):
 
 
 def nPrintProcess(*args, stdin=None, stdout=None, stderr=None):
-    """TODO
+    """Construct a subprocess to execute the `nprint` command.
+
+    Argumentation reflects that of `subprocess.Popen`.
+
+    The `PIPE` sentinel is made available via the object of the
+    constructor:
+
+        nPrintProcess.PIPE
+
+    If the `nprint` command cannot be found on the PATH, then
+    `NoCommand` is raised. This exception is also made available on the
+    constructor --
+
+        nPrintProcess.NoCommand
+
+    Returns the constructed `subprocess.Popen` object with which to
+    monitor the running command.
 
     """
     return subprocess.Popen(

--- a/src/nprintml/net/step.py
+++ b/src/nprintml/net/step.py
@@ -6,12 +6,13 @@ import pathlib
 import re
 import sys
 import textwrap
+import time
 import typing
 
 import nprintml
 from nprintml import pipeline
 
-from .execute import nprint
+from .execute import CommandError, nprint, nPrintProcess
 
 
 class NetResult(typing.NamedTuple):
@@ -203,6 +204,46 @@ class Net(pipeline.Step):
         outpath = npt_file or outdir / 'netcap.npt'
         yield from ('--write_file', str(outpath))
 
+    @staticmethod
+    def generate_files(args):
+        if args.pcap_file or args.pcap_dir:
+            # stream pair of pcap path & "basis" for reconstructing tree
+            for pcap_file in args.pcap_file:
+                yield (pcap_file, None)
+
+            for pcap_dir in args.pcap_dir:
+                for pcap_file in pcap_dir.rglob('*.pcap'):
+                    yield (pcap_file, pcap_dir)
+
+            return
+
+        yield (None, None)
+
+    def generate_procs(self, args, pcap_files, outdir):
+        for (pcap_file, dir_basis) in pcap_files:
+            npt_file = self.make_output_path(outdir, pcap_file, dir_basis)
+
+            yield nPrintProcess(
+                *self.generate_argv(args, pcap_file, npt_file),
+            )
+
+    @staticmethod
+    def pool_procs(proc_stream, size, wait=None):
+        sleep_time = os.sched_rr_get_interval(0) if wait is None else wait / 1_000
+
+        pool = list(itertools.islice(proc_stream, size))
+
+        while any(pool):
+            if sleep_time != 0:
+                time.sleep(sleep_time)
+
+            for (index, proc) in enumerate(pool):
+                if proc and proc.poll() is not None:
+                    if proc.returncode != 0:
+                        raise CommandError
+
+                    pool[index] = next(proc_stream, None)
+
     def __call__(self, args, results):
         try:
             warn_version_mismatch()
@@ -212,23 +253,11 @@ class Net(pipeline.Step):
 
         outdir = self.make_output_directory(args)
 
-        if args.pcap_file or args.pcap_dir:
-            # stream pair of pcap path & "basis" for reconstructing tree
-            pcap_files = itertools.chain(
-                zip(args.pcap_file, itertools.repeat(None)),
-                itertools.chain.from_iterable(
-                    zip(pcap_dir.rglob('*.pcap'), itertools.repeat(pcap_dir))
-                    for pcap_dir in args.pcap_dir
-                ),
-            )
-        else:
-            pcap_files = ((None, None),)
+        pcap_files = self.generate_files(args)
 
-        for (pcap_file, dir_basis) in pcap_files:
-            npt_file = self.make_output_path(outdir, pcap_file, dir_basis)
-            nprint(
-                *self.generate_argv(args, pcap_file, npt_file),
-            )
+        processes = self.generate_procs(args, pcap_files, outdir)
+
+        self.pool_procs(processes, size=args.concurrency)
 
         return NetResult(outdir)
 

--- a/src/nprintml/net/step.py
+++ b/src/nprintml/net/step.py
@@ -175,6 +175,21 @@ class Net(pipeline.Step):
         npt_path.parent.mkdir(parents=True, exist_ok=True)
         return npt_path
 
+    @staticmethod
+    def generate_files(args):
+        if args.pcap_file or args.pcap_dir:
+            # stream pair of pcap path & "basis" for reconstructing tree
+            for pcap_file in args.pcap_file:
+                yield (pcap_file, None)
+
+            for pcap_dir in args.pcap_dir:
+                for pcap_file in pcap_dir.rglob('*.pcap'):
+                    yield (pcap_file, pcap_dir)
+
+            return
+
+        yield (None, None)
+
     def generate_argv(self, args, pcap_file=None, npt_file=None):
         """Construct arguments for `nprint` command."""
         # generate shared/global arguments
@@ -203,21 +218,6 @@ class Net(pipeline.Step):
         outdir = self.get_output_directory(args)
         outpath = npt_file or outdir / 'netcap.npt'
         yield from ('--write_file', str(outpath))
-
-    @staticmethod
-    def generate_files(args):
-        if args.pcap_file or args.pcap_dir:
-            # stream pair of pcap path & "basis" for reconstructing tree
-            for pcap_file in args.pcap_file:
-                yield (pcap_file, None)
-
-            for pcap_dir in args.pcap_dir:
-                for pcap_file in pcap_dir.rglob('*.pcap'):
-                    yield (pcap_file, pcap_dir)
-
-            return
-
-        yield (None, None)
 
     def generate_procs(self, args, pcap_files, outdir):
         for (pcap_file, dir_basis) in pcap_files:


### PR DESCRIPTION
--concurrency is made to default to number of CPUs reported by the
scheduler as available to the nprintML process.

AutoML's --threads is preserved, but now defaults to value of --concurrency.

resolves #26