### PR TITLE
upgrade autogluon to 0.1.0 ... as well as everything else

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -7,30 +7,28 @@ from setuptools import find_packages, setup
 README_PATH = pathlib.Path(__file__).parent / 'README.md'
 
 INSTALL_REQUIRES = [
-    'argparse-formatter == 1.2',
+    'argparse-formatter ~= 1.4',
 
-    'numpy ~= 1.19.4',
-    'pandas ~= 1.1.4',
+    'autogluon.tabular ~= 0.1.0',
 
-    # for cuda, e.g.: mxnet_cu101 < 2.0.0
-    'mxnet < 2.0.0',
+    # autogluon.core *also* requires numpy, so match autogluon
+    'numpy == 1.19.5',
 
-    'autogluon ~= 0.0.15',
-    'scikit-learn ~= 0.23.2',
+    'pandas ~= 1.1.5',
 
-    'matplotlib ~= 3.3.3',
-    'seaborn ~= 0.11.0',
+    'matplotlib ~= 3.3.4',
+    'seaborn ~= 0.11.1',
 ]
 
 _DEV_REQUIRES = [
     'argcmdr==0.7.0',
     'bumpversion==0.6.0',
-    'twine==3.2.0',
-    'wheel==0.35.1',
+    'twine==3.4.0',
+    'wheel==0.36.2',
 ]
 
 _TESTS_REQUIRE = [
-    'tox==3.20.1',
+    'tox==3.23.0',
 ]
 
 EXTRAS_REQUIRE = {

--- a/src/nprintml/learn/automl.py
+++ b/src/nprintml/learn/automl.py
@@ -128,26 +128,6 @@ class AutoML:
         self.make_pr(binarizer.classes_, binarized_labels, y_proba)
         self.make_roc(binarizer.classes_, binarized_labels, y_proba)
         self.make_cfmx(binarizer.classes_, y_true, y_pred)
-        self.make_stat_report(binarizer.classes_, binarized_labels, y_true, y_pred, y_proba)
-
-    def make_stat_report(self, classes, binarized_labels, y_true, y_pred, y_proba):
-        """Make basic stat report that many users would put in a results summary table
-
-        """
-        ba = balanced_accuracy_score(y_true, y_pred)
-        f1_macro = f1_score(y_true, y_pred, average='macro')
-        f1_micro = f1_score(y_true, y_pred, average='micro')
-        if len(classes) == 2:
-            multi_class='raise'
-        else:
-            multi_class='ovr'
-        roc_macro = roc_auc_score(y_true, y_proba, average='macro', multi_class=multi_class)
-        roc_micro = roc_auc_score(y_true, y_proba, average='micro', multi_class=multi_class)
-        roc_weighted = roc_auc_score(y_true, y_proba, average='weighted', multi_class=multi_class)
-
-        with open(self.outpath / 'stat-report.csv', 'w') as f:
-            f.write('f1_micro,f1_macro,balanced_accuracy,roc_macro,roc_micro\n')
-            f.write(f'{f1_micro:.2f},{f1_macro:.2f},{ba:.2f},{roc_macro:.2f},{roc_micro:.2f},{roc_weighted:.2f}\n')
 
     def make_cfmx(self, classes, y_true, y_pred):
         """Make confusion matrix without printing exact values.
@@ -176,7 +156,7 @@ class AutoML:
             plt_ax = self._make_binary_pr(y_true_bin.ravel(), y_proba.ravel())
         else:
             for i, class_label in enumerate(classes):
-                plt_ax = self._make_binary_pr(y_true_bin[:, i], y_proba[:, i],
+                plt_ax = self._make_binary_pr(y_true_bin[:, i], y_proba.iloc[:, i],
                                               class_label=class_label)
 
         # Split up the line styles to make them unique
@@ -214,7 +194,7 @@ class AutoML:
             plt_ax = self._make_binary_roc(y_true_bin.ravel(), y_proba.ravel())
         else:
             for i, class_label in enumerate(classes):
-                plt_ax = self._make_binary_roc(y_true_bin[:, i], y_proba[:, i],
+                plt_ax = self._make_binary_roc(y_true_bin[:, i], y_proba.iloc[:, i],
                                                class_label=class_label)
 
         # Split up the line styles to make them unique

--- a/src/nprintml/learn/automl.py
+++ b/src/nprintml/learn/automl.py
@@ -129,14 +129,23 @@ class AutoML:
         self.make_stat_report(binarizer.classes_, binarized_labels, y_true, y_pred, y_proba)
 
     def make_stat_report(self, classes, binarized_labels, y_true, y_pred, y_proba):
+        """Make basic stat report that many users would put in a results summary table
+
+        """
         ba = balanced_accuracy_score(y_true, y_pred)
-        f1_micro = f1_score(y_true, y_pred, average='micro')
         f1_macro = f1_score(y_true, y_pred, average='macro')
-        roc_macro = roc_auc_score(y_true, y_proba, average='macro', multi_class='ovr')
+        f1_micro = f1_score(y_true, y_pred, average='micro')
+        if len(classes) == 2:
+            multi_class='raise'
+        else:
+            multi_class='ovr'
+        roc_macro = roc_auc_score(y_true, y_proba, average='macro', multi_class=multi_class)
+        roc_micro = roc_auc_score(y_true, y_proba, average='micro', multi_class=multi_class)
+        roc_weighted = roc_auc_score(y_true, y_proba, average='weighted', multi_class=multi_class)
 
         with open(self.outpath / 'stat-report.csv', 'w') as f:
-            f.write('f1_micro,f1_macro,balanced_accuracy,roc_macro\n')
-            f.write('{0},{1},{2},{3}\n'.format(f1_micro, f1_macro, ba, roc_macro))
+            f.write('f1_micro,f1_macro,balanced_accuracy,roc_macro,roc_micro\n')
+            f.write(f'{f1_micro:.2f},{f1_macro:.2f},{ba:.2f},{roc_macro:.2f},{roc_micro:.2f},{roc_weighted:.2f}\n')
 
     def make_cfmx(self, classes, y_true, y_pred):
         """Make confusion matrix without printing exact values.

--- a/src/nprintml/learn/automl.py
+++ b/src/nprintml/learn/automl.py
@@ -18,6 +18,9 @@ from sklearn.metrics import (
     roc_curve,
     auc,
     precision_recall_curve,
+    balanced_accuracy_score,
+    roc_auc_score,
+    f1_score,
     average_precision_score,
     confusion_matrix,
     ConfusionMatrixDisplay,
@@ -104,6 +107,7 @@ class AutoML:
         leaderboard = predictor.leaderboard(test_data, silent=True)
         leaderboard.set_index('model').sort_index().to_csv(self.outpath / 'leaderboard.csv')
 
+
     def graph_all(self, predictor, test_data):
         """Generate ROC, PR and confusion matrix graphs for the
         classification tasks.
@@ -122,6 +126,17 @@ class AutoML:
         self.make_pr(binarizer.classes_, binarized_labels, y_proba)
         self.make_roc(binarizer.classes_, binarized_labels, y_proba)
         self.make_cfmx(binarizer.classes_, y_true, y_pred)
+        self.make_stat_report(binarizer.classes_, binarized_labels, y_true, y_pred, y_proba)
+
+    def make_stat_report(self, classes, binarized_labels, y_true, y_pred, y_proba):
+        ba = balanced_accuracy_score(y_true, y_pred)
+        f1_micro = f1_score(y_true, y_pred, average='micro')
+        f1_macro = f1_score(y_true, y_pred, average='macro')
+        roc_macro = roc_auc_score(y_true, y_proba, average='macro', multi_class='ovr')
+
+        with open(self.outpath / 'stat-report.csv', 'w') as f:
+            f.write('f1_micro,f1_macro,balanced_accuracy,roc_macro\n')
+            f.write('{0},{1},{2},{3}\n'.format(f1_micro, f1_macro, ba, roc_macro))
 
     def make_cfmx(self, classes, y_true, y_pred):
         """Make confusion matrix without printing exact values.

--- a/src/nprintml/learn/step.py
+++ b/src/nprintml/learn/step.py
@@ -60,19 +60,12 @@ class Learn(pipeline.Step):
         )
         group_parser.add_argument(
             '--limit',
-            default=AutoML.TIME_LIMITS,
-            dest='time_limits',
+            default=AutoML.TIME_LIMIT,
+            dest='time_limit',
             metavar='INTEGER',
             type=int,
             help="maximum time (seconds) over which to train each model "
-                 f"(default: {AutoML.TIME_LIMITS})",
-        )
-        group_parser.add_argument(
-            '--threads',
-            dest='n_threads',
-            metavar='INTEGER',
-            type=NumericRangeType(int, (0, None)),
-            help="number of CPU threads to dedicate to training (default: same as --concurrency)",
+                 f"(default: {AutoML.TIME_LIMIT})",
         )
 
     def __call__(self, args, results):
@@ -82,8 +75,7 @@ class Learn(pipeline.Step):
             test_size=args.test_size,
             eval_metric=args.eval_metric,
             quality=args.quality,
-            time_limits=args.time_limits,
-            n_threads=(args.n_threads or args.concurrency),
+            time_limit=args.time_limit,
             verbosity=args.verbosity,
         )
 

--- a/src/nprintml/net/step.py
+++ b/src/nprintml/net/step.py
@@ -265,6 +265,13 @@ class Net(pipeline.Step):
                 *self.generate_argv(pcap_file, npt_file),
             )
 
+    def output_nprint_config(self, outdir):
+        args = ' '.join(list(self.generate_argv())[:-2])
+        nprint_cmd = f'nprint {args}\n'
+        outfile = outdir / 'nprint.cfg'
+        with open(outfile, 'w') as f:
+            f.write(nprint_cmd)
+
     @staticmethod
     def pool_procs(proc_stream, size, wait=None):
         sleep_time = os.sched_rr_get_interval(0) if wait is None else wait / 1_000
@@ -293,6 +300,8 @@ class Net(pipeline.Step):
 
     def __call__(self, args, results):
         outdir = self.make_output_directory()
+        
+        self.output_nprint_config(outdir)
 
         pcap_files = self.generate_files()
 

--- a/src/nprintml/net/step.py
+++ b/src/nprintml/net/step.py
@@ -265,13 +265,6 @@ class Net(pipeline.Step):
                 *self.generate_argv(pcap_file, npt_file),
             )
 
-    def output_nprint_config(self, outdir):
-        args = ' '.join(list(self.generate_argv())[:-2])
-        nprint_cmd = f'nprint {args}\n'
-        outfile = outdir / 'nprint.cfg'
-        with open(outfile, 'w') as f:
-            f.write(nprint_cmd)
-
     @staticmethod
     def pool_procs(proc_stream, size, wait=None):
         sleep_time = os.sched_rr_get_interval(0) if wait is None else wait / 1_000
@@ -301,8 +294,6 @@ class Net(pipeline.Step):
     def __call__(self, args, results):
         outdir = self.make_output_directory()
         
-        self.output_nprint_config(outdir)
-
         pcap_files = self.generate_files()
 
         file_stream = self.filter_files(pcap_files, outdir, results.labels)


### PR DESCRIPTION
## Changes

* removes requirement for mxnet -- this and others end-user can now
install on their own, should they want those models

* now *only* autogluon.tabluar (namespaced) sub-package required --
build/install and process start-up times significantly improved

* scikit-learn version pin no longer appears to be required and so removed -- (autogluon can manage its requirement itself)

* use of autogluon.tabular made to reflect new API

## Performance

Ad-hoc time-testing revealed that on my laptop it previously took ~2m30s to do a complete build/install/test; now it takes ~1m50s.

Similar, for process-start, it previously took ~5.3s to run `--help`; now it takes ~2.3s.

(Obviously that timing for `--help` still stinks; but, that's a huge improvement. And, though it's a low priority, we can definitely improve it further.)

---

resolves #45