### PR TITLE
cfg with pcap and in base dir to not ruin label aggregator

### DIFF
--- a/src/nprintml/net/step.py
+++ b/src/nprintml/net/step.py
@@ -231,6 +231,13 @@ class Net(pipeline.Step):
         outpath = npt_file or outdir / 'netcap.npt'
         yield from ('--write_file', str(outpath))
 
+    def output_nprint_config(self):
+        args = ' '.join(list(self.generate_argv())[:-2])
+        nprint_cmd = f'nprint {args} -P [input_pcap]\n'
+        outfile = self.args.outdir / 'nprint.cfg'
+        with open(outfile, 'w') as f:
+            f.write(nprint_cmd)
+
     def filter_files(self, pcap_files, outdir, labels=None):
         skipped_files = collections.deque(maxlen=4)
         skipped_count = 0
@@ -292,6 +299,8 @@ class Net(pipeline.Step):
         self.args = args
 
     def __call__(self, args, results):
+        self.output_nprint_config()
+
         outdir = self.make_output_directory()
         
         pcap_files = self.generate_files()

--- a/src/nprintml/net/step.py
+++ b/src/nprintml/net/step.py
@@ -231,12 +231,10 @@ class Net(pipeline.Step):
         outpath = npt_file or outdir / 'netcap.npt'
         yield from ('--write_file', str(outpath))
 
-    def output_nprint_config(self):
-        args = ' '.join(list(self.generate_argv())[:-2])
-        nprint_cmd = f'nprint {args} -P [input_pcap]\n'
+    def write_nprint_config(self):
         outfile = self.args.outdir / 'nprint.cfg'
-        with open(outfile, 'w') as f:
-            f.write(nprint_cmd)
+        args = ' '.join(self.generate_argv('[input_pcap]'))
+        outfile.write_text(f'nprint {args}\n')
 
     def filter_files(self, pcap_files, outdir, labels=None):
         skipped_files = collections.deque(maxlen=4)
@@ -299,7 +297,7 @@ class Net(pipeline.Step):
         self.args = args
 
     def __call__(self, args, results):
-        self.output_nprint_config()
+        self.write_nprint_config()
 
         outdir = self.make_output_directory()
         


### PR DESCRIPTION
Outputs the nPrint command we use to a `nprint.cfg` file for user's to go run nPrint on their own if interested (have been asked before). I leverage the base output directory because if we throw it in the `nprint` directory with the output files the label aggregator breaks when trying to search the files rather than creating the edge case for `﻿nprint.cfg`.

Very small amount of code added.