### PR TITLE
buffers over files | nPrint optimization

### DIFF
--- a/src/nprintml/__init__.py
+++ b/src/nprintml/__init__.py
@@ -1,3 +1,3 @@
 __version__ = '0.0.7'
 
-__nprint_version__ = '1.1.6'
+__nprint_version__ = '1.1.7'

--- a/src/nprintml/cli.py
+++ b/src/nprintml/cli.py
@@ -11,6 +11,7 @@ import argparse_formatter
 
 import nprintml
 from nprintml.pipeline import Pipeline
+from nprintml.util import NumericRangeType
 
 # ensure default steps of pipeline auto-load
 import nprintml.net.step
@@ -118,9 +119,9 @@ def build_parser(**parser_kwargs):
         '--concurrency',
         default=cpu_available_count,
         metavar='INTEGER',
-        type=int,
-        help="maximum number of concurrent processes to use (defaults to number "
-             f"reported by scheduler: {cpu_available_count})",
+        type=NumericRangeType(int, (0, None)),
+        help="maximum number of concurrent processes to apply to data preparation "
+             f"(defaults to number reported by scheduler: {cpu_available_count})",
     )
 
     output_default = get_default_directory()

--- a/src/nprintml/label/aggregator/__init__.py
+++ b/src/nprintml/label/aggregator/__init__.py
@@ -15,7 +15,13 @@ A lazy-loading `registry` of these classes is provided for their dynamic
 inspection and retrieval.
 
 """
-from .base import LabelAggregator, LabelError, PluginRegistry  # noqa: F401
+from .base import (  # noqa: F401
+    AggregationLengthError,
+    AggregationPathError,
+    LabelAggregator,
+    LabelError,
+    PluginRegistry,
+)
 
 
 registry = PluginRegistry(LabelAggregator,

--- a/src/nprintml/label/step.py
+++ b/src/nprintml/label/step.py
@@ -30,7 +30,7 @@ class Label(pipeline.Step):
     """
     __pre_provides__ = ('labels',)
     __provides__ = LabelResult
-    __requires__ = ('nprint_path',)
+    __requires__ = ('nprint_path', 'nprint_stream')
 
     def __init__(self, parser):
         group_parser = parser.add_argument_group(
@@ -68,10 +68,9 @@ class Label(pipeline.Step):
             help="drop columns which do not appear to provide any predictive signal",
         )
         group_parser.add_argument(
-            '--no-write-features',
+            '--no-save-features',
             action='store_false',
-            default=True,
-            dest='write_features',
+            dest='save_features',
             help="disable writing of features to disk (enabled by default for inspection & reuse)",
         )
 
@@ -85,12 +84,13 @@ class Label(pipeline.Step):
 
     def __call__(self, args, results):
         features = self.aggregator(
-            results.nprint_path,
+            results.nprint_stream,
+            path_input_base=results.nprint_path,
             compress=args.compress,
             sample_size=args.sample_size,
         )
 
-        if args.write_features:
+        if args.save_features:
             outdir = args.outdir / 'feature'
             outdir.mkdir()
 

--- a/src/nprintml/learn/step.py
+++ b/src/nprintml/learn/step.py
@@ -1,9 +1,9 @@
 """Pipeline Step to build models via AutoML: Learn"""
-import argparse
 import pathlib
 import typing
 
 from nprintml import pipeline
+from nprintml.util import NumericRangeType
 
 from . import AutoML
 
@@ -83,98 +83,3 @@ class Learn(pipeline.Step):
             graphs_path=learn.graphs_path,
             models_path=learn.models_path,
         )
-
-
-class NumericRangeType:
-    """Argument type validating that given value is of configured
-    numeric type and bounds.
-
-    Bounds may be specified as either `list` or `tuple`, the convention
-    indicating whether bounds are "inclusive" or "non-inclusive",
-    respectively.
-
-    Either the lower or upper bound may be specified as `None`,
-    indicating no bound.
-
-    For example:
-
-        parser.add_argument(
-            '--test-size',
-            default=0.3,
-            metavar='FLOAT',
-            type=NumericRangeType(float, (0, 1)),
-        )
-
-    The above argument, `--test-size`, will cast its input to `float`,
-    (or print an error for non-float input). Moreover, a "not in range"
-    error will be printed for inputs equal to zero or equal to or
-    greater than one.
-
-        parser.add_argument(
-            '--threads',
-            default=1,
-            metavar='INTEGER',
-            type=NumericRangeType(int, (0, None)),
-        )
-
-    In the above example, inputs are instead enforced as `int`; and,
-    there is _only_ a lower bound -- inputs must only be greater than
-    zero.
-
-        parser.add_argument(
-            '-q', '--quality',
-            default=0,
-            metavar='INTEGER',
-            type=NumericRangeType(int, [0, 4]),
-        )
-
-    Arguments may also be given inclusive bounds, as above -- inputs to
-    this example must be greater than or equal to zero, and less than or
-    equal to four.
-
-    """
-    bounds_message = "upper and lower bounds must be list or tuple of two elements"
-
-    def __init__(self, numeric_type, bounds):
-        self.numeric_type = numeric_type
-
-        try:
-            (self.lower_bound, self.upper_bound) = bounds
-        except ValueError as exc:
-            raise ValueError(f"{self.bounds_message} not: {bounds!r}") from exc
-        except TypeError as exc:
-            raise TypeError(
-                f"{self.bounds_message} not {bounds.__class__.__name__}: {bounds!r}"
-            ) from exc
-
-        if isinstance(bounds, tuple):
-            self.inclusive = False
-        elif isinstance(bounds, list):
-            self.inclusive = True
-        else:
-            raise TypeError(f"{self.bounds_message} not {bounds.__class__.__name__}: {bounds!r}")
-
-    def __call__(self, value):
-        try:
-            number = self.numeric_type(value)
-        except ValueError:
-            raise argparse.ArgumentTypeError(f"not {self.numeric_type.__name__}: {value!r}")
-
-        if self.inclusive:
-            if (
-                (self.lower_bound is not None and number < self.lower_bound) or
-                (self.upper_bound is not None and number > self.upper_bound)
-            ):
-                raise argparse.ArgumentTypeError(
-                    f"not in range [{self.lower_bound}, {self.upper_bound}]: {number!r}"
-                )
-        else:
-            if (
-                (self.lower_bound is not None and number <= self.lower_bound) or
-                (self.upper_bound is not None and number >= self.upper_bound)
-            ):
-                raise argparse.ArgumentTypeError(
-                    f"not in range ({self.lower_bound}, {self.upper_bound}): {number!r}"
-                )
-
-        return number

--- a/src/nprintml/pipeline.py
+++ b/src/nprintml/pipeline.py
@@ -348,6 +348,7 @@ class Pipeline(list):
         self.results = self.results_class() if results is None else results
 
         self.results.__timing__ = Timing()
+        self.results.__timing_steps__ = {}
 
         with self.results.__timing__:
             # pre-pipline
@@ -362,7 +363,11 @@ class Pipeline(list):
                 if not results_available.issuperset(step.__requires__):
                     raise StepRequirementError(run, self, results_available)
 
-                step_results = step(args, self.results)
+                step_timing = self.results.__timing_steps__[step] = Timing()
+
+                with step_timing:
+                    step_results = step(args, self.results)
+
                 if step_results is not None:
                     self.merge(step_results)
 

--- a/src/nprintml/pipeline.py
+++ b/src/nprintml/pipeline.py
@@ -140,6 +140,7 @@ metaclass level, via `__default_registry__`.)
 import abc
 import collections
 import itertools
+import time
 import types
 
 
@@ -346,26 +347,29 @@ class Pipeline(list):
         """Construct an iterator to execute the steps of the pipeline."""
         self.results = self.results_class() if results is None else results
 
-        # pre-pipline
-        for step in self:
-            step.__pre__(parser, args, self.results)
+        self.results.__timing__ = Timing()
 
-        run = []
+        with self.results.__timing__:
+            # pre-pipline
+            for step in self:
+                step.__pre__(parser, args, self.results)
 
-        for step in self[:]:
-            results_available = set(self.results.__dict__.keys())
+            run = []
 
-            if not results_available.issuperset(step.__requires__):
-                raise StepRequirementError(run, self, results_available)
+            for step in self[:]:
+                results_available = set(self.results.__dict__.keys())
 
-            step_results = step(args, self.results)
-            if step_results is not None:
-                self.merge(step_results)
+                if not results_available.issuperset(step.__requires__):
+                    raise StepRequirementError(run, self, results_available)
 
-            run.append(step)
-            self.remove(step)
+                step_results = step(args, self.results)
+                if step_results is not None:
+                    self.merge(step_results)
 
-            yield (step, step_results)
+                run.append(step)
+                self.remove(step)
+
+                yield (step, step_results)
 
     def exhaust(self, args, results=None):
         """Execute the steps of the pipeline (non-iteratively)."""
@@ -407,3 +411,52 @@ class StepRequirementError(PipelineError):
         self.steps_run = steps_run
         self.steps_remaining = steps_remaining
         self.results_available = results_available
+
+
+class Timing:
+
+    class StaleTimer(ValueError):
+        pass
+
+    def __init__(self):
+        self.t0 = self.t1 = self.proc0 = self.proc1 = None
+
+    def start(self):
+        if self.t0 is not None:
+            raise self.StaleTimer
+
+        self.t0 = time.time()
+        self.proc0 = time.process_time()
+
+    def stop(self):
+        if self.t1 is not None:
+            raise self.StaleTimer
+
+        self.t1 = time.time()
+        self.proc1 = time.process_time()
+
+    def __enter__(self):
+        self.start()
+        return self
+
+    def __exit__(self, *exc_info):
+        self.stop()
+
+    @property
+    def time_elapsed(self):
+        if self.t0 is None or self.t1 is None:
+            return None
+
+        return self.t1 - self.t0
+
+    @property
+    def proc_elapsed(self):
+        if self.proc0 is None or self.proc1 is None:
+            return None
+
+        return self.proc1 - self.proc0
+
+    def __repr__(self):
+        return (f'<{self.__class__.__name__}: '
+                f'time elapsed {self.time_elapsed} | '
+                f'process time elapsed {self.proc_elapsed}>')

--- a/src/nprintml/util.py
+++ b/src/nprintml/util.py
@@ -1,4 +1,56 @@
 import argparse
+import io
+import itertools
+
+
+Empty = object()
+
+class PrimedIterator:
+
+    @classmethod
+    def prime(cls, iterator, default=Empty):
+        """Retrieve the first item from the given iterator and return a new
+        iterator over *all* elements.
+
+        No elements from the original iterator are missed by the returned
+        iterator.
+
+        Rather, the iterator is thereby initiated, and tested for emptiness.
+
+        This can be a useful helper in emptiness checks (which must then
+        construct this secondary iterator wrapper over the first, retrieved
+        element and the remainder).
+
+        This may also be useful in initializing complex generator functions
+        (e.g. those with buffers), without retrieving more than one item
+        from its stream, and maintaining its full contents.
+
+        If a second argument, the default, is given, and the iterator is
+        already empty/exhausted, then this default is returned instead of
+        raising StopIteration (as with `next`).
+
+        """
+        try:
+            first = next(iterator)
+        except StopIteration:
+            if default is not Empty:
+                return default
+
+            raise
+
+        return cls(first, iterator)
+
+    def __init__(self, first, iterator):
+        self.iterator = iterator
+        self.__chain__ = itertools.chain((first,), iterator)
+
+    def __iter__(self):
+        return self.__chain__
+
+    def __repr__(self):
+        return f'({self.__class__.__name__}: {self.iterator!r})'
+
+prime_iterator = PrimedIterator.prime
 
 
 class HelpAction(argparse.Action):
@@ -32,3 +84,118 @@ class HelpAction(argparse.Action):
     def __call__(self, parser, namespace, values, option_string=None):
         self.help_action(parser, namespace, values, option_string)
         parser.exit()
+
+
+class NumericRangeType:
+    """Argument type validating that given value is of configured
+    numeric type and bounds.
+
+    Bounds may be specified as either `list` or `tuple`, the convention
+    indicating whether bounds are "inclusive" or "non-inclusive",
+    respectively.
+
+    Either the lower or upper bound may be specified as `None`,
+    indicating no bound.
+
+    For example:
+
+        parser.add_argument(
+            '--test-size',
+            default=0.3,
+            metavar='FLOAT',
+            type=NumericRangeType(float, (0, 1)),
+        )
+
+    The above argument, `--test-size`, will cast its input to `float`,
+    (or print an error for non-float input). Moreover, a "not in range"
+    error will be printed for inputs equal to zero or equal to or
+    greater than one.
+
+        parser.add_argument(
+            '--threads',
+            default=1,
+            metavar='INTEGER',
+            type=NumericRangeType(int, (0, None)),
+        )
+
+    In the above example, inputs are instead enforced as `int`; and,
+    there is _only_ a lower bound -- inputs must only be greater than
+    zero.
+
+        parser.add_argument(
+            '-q', '--quality',
+            default=0,
+            metavar='INTEGER',
+            type=NumericRangeType(int, [0, 4]),
+        )
+
+    Arguments may also be given inclusive bounds, as above -- inputs to
+    this example must be greater than or equal to zero, and less than or
+    equal to four.
+
+    """
+    bounds_message = "upper and lower bounds must be list or tuple of two elements"
+
+    def __init__(self, numeric_type, bounds):
+        self.numeric_type = numeric_type
+
+        try:
+            (self.lower_bound, self.upper_bound) = bounds
+        except ValueError as exc:
+            raise ValueError(f"{self.bounds_message} not: {bounds!r}") from exc
+        except TypeError as exc:
+            raise TypeError(
+                f"{self.bounds_message} not {bounds.__class__.__name__}: {bounds!r}"
+            ) from exc
+
+        if isinstance(bounds, tuple):
+            self.inclusive = False
+        elif isinstance(bounds, list):
+            self.inclusive = True
+        else:
+            raise TypeError(f"{self.bounds_message} not {bounds.__class__.__name__}: {bounds!r}")
+
+    def __call__(self, value):
+        try:
+            number = self.numeric_type(value)
+        except ValueError:
+            raise argparse.ArgumentTypeError(f"not {self.numeric_type.__name__}: {value!r}")
+
+        if self.inclusive:
+            if (
+                (self.lower_bound is not None and number < self.lower_bound) or
+                (self.upper_bound is not None and number > self.upper_bound)
+            ):
+                raise argparse.ArgumentTypeError(
+                    f"not in range [{self.lower_bound}, {self.upper_bound}]: {number!r}"
+                )
+        else:
+            if (
+                (self.lower_bound is not None and number <= self.lower_bound) or
+                (self.upper_bound is not None and number >= self.upper_bound)
+            ):
+                raise argparse.ArgumentTypeError(
+                    f"not in range ({self.lower_bound}, {self.upper_bound}): {number!r}"
+                )
+
+        return number
+
+
+class NamedStringIO(io.StringIO):
+    """StringIO featuring a `name` attribute to reflect the path
+    represented by its contents.
+
+    """
+    def __init__(self, initial_value='', newline='\n', name=None):
+        super().__init__(initial_value, newline)
+        self.name = name
+
+
+class NamedBytesIO(io.BytesIO):
+    """BytesIO featuring a `name` attribute to reflect the path
+    represented by its contents.
+
+    """
+    def __init__(self, initial_bytes=b'', name=None):
+        super().__init__(initial_bytes)
+        self.name = name

--- a/test/cli_test/test_pcap.py
+++ b/test/cli_test/test_pcap.py
@@ -40,6 +40,34 @@ class TestPcap(CLITestCase):
                         # its stdout a little harder
         )
 
+        npt_dir = temp_path / 'nprint'
+        self.assertFalse(npt_dir.exists())
+
+        feature_path = temp_path / 'feature' / 'features.csv.gz'
+        self.assertTrue(feature_path.exists())
+
+        graphs_path = temp_path / 'model' / 'graphs'
+        self.assertTrue(any(graphs_path.glob('*.pdf')))
+
+        models_path = temp_path / 'model' / 'models'
+        self.assertTrue(any(models_path.rglob('*.pkl')))
+
+    @testdir
+    def test_pcap_file_save_npt(self, tempdir):
+        temp_path = pathlib.Path(tempdir)
+
+        self.try_execute(
+            '--save-nprint',
+            '--tcp',
+            '--ipv4',
+            '--aggregator', 'index',
+            '--label-file', TEST_DATA / 'single-pcap' / 'labels.txt',
+            '--pcap-file', TEST_DATA / 'single-pcap' / 'test.pcap',
+            '--output', temp_path,
+            '--quiet',  # autogluon's threading makes capturing/suppressing
+                        # its stdout a little harder
+        )
+
         npt_path = temp_path / 'nprint' / 'test.npt'
         self.assertTrue(npt_path.exists())
 
@@ -57,6 +85,34 @@ class TestPcap(CLITestCase):
         temp_path = pathlib.Path(tempdir)
 
         self.try_execute(
+            '--tcp',
+            '--ipv4',
+            '--aggregator', 'pcap',
+            '--label-file', TEST_DATA / 'dir-pcap' / 'labels.txt',
+            '--pcap-dir', TEST_DATA / 'dir-pcap' / 'pcaps',
+            '--output', temp_path,
+            '--quiet',  # autogluon's threading makes capturing/suppressing
+                        # its stdout a little harder
+        )
+
+        npt_dir = temp_path / 'nprint'
+        self.assertFalse(npt_dir.exists())
+
+        feature_path = temp_path / 'feature' / 'features.csv.gz'
+        self.assertTrue(feature_path.exists())
+
+        graphs_path = temp_path / 'model' / 'graphs'
+        self.assertTrue(any(graphs_path.glob('*.pdf')))
+
+        models_path = temp_path / 'model' / 'models'
+        self.assertTrue(any(models_path.rglob('*.pkl')))
+
+    @testdir
+    def test_pcap_directory_save_npt(self, tempdir):
+        temp_path = pathlib.Path(tempdir)
+
+        self.try_execute(
+            '--save-nprint',
             '--tcp',
             '--ipv4',
             '--aggregator', 'pcap',
@@ -91,6 +147,7 @@ class TestPcap(CLITestCase):
         temp_path = pathlib.Path(tempdir)
 
         self.try_execute(
+            '--save-nprint',
             '--tcp',
             '--ipv4',
             '--aggregator', 'pcap',


### PR DESCRIPTION
This branch features an implementation of the nPrint -> features pipeline wherein nPrint results need not be stored to disk and reread from disk, and instead these results are passed to labeling/aggregation as a stream of in-memory buffers.

---

* streams nPrint results to subsequent pipeline step(s) as in-memory buffers
* user is relieved of having to store nPrint result files on disk (even temporarily). Should they want these results saved (for debugging purposes) they may opt in to this.
* Labeling step adds support for stream of file-like objects of nPrint results
* Pipeline records timing information of its invocation in results
* Step- and lower-level timing information is also added to the pipeline results
* --concurrency checks that value is 1 or greater
* utilities added (for use by Net step)

See: #39