### PR TITLE
Ml speed

### DIFF
--- a/src/nprintml/learn/automl.py
+++ b/src/nprintml/learn/automl.py
@@ -102,14 +102,10 @@ class AutoML:
                                             enable_datetime_features=False,
                                             enable_text_special_features=False,
                                             enable_text_ngram_features=False
-                                           )
-    
+        ) 
         # create our own feature metadata object as we know what the type of every
         # feature we have. Skip the label column in the training data when doing so
-        d = {}
-        for col in train_data.columns[:-1]:
-            d[col] = 'int'
-        fmd = FeatureMetadata(d)
+        fmd = FeatureMetadata(dict.fromkeys(train_data.columns[:-1], 'int'))
 
         task = TabularPredictor(
             label='label',

--- a/src/nprintml/learn/automl.py
+++ b/src/nprintml/learn/automl.py
@@ -101,8 +101,7 @@ class AutoML:
         fg = AutoMLPipelineFeatureGenerator(enable_categorical_features=False,
                                             enable_datetime_features=False,
                                             enable_text_special_features=False,
-                                            enable_text_ngram_features=False
-        ) 
+                                            enable_text_ngram_features=False)
         # create our own feature metadata object as we know what the type of every
         # feature we have. Skip the label column in the training data when doing so
         fmd = FeatureMetadata(dict.fromkeys(train_data.columns[:-1], 'int'))

--- a/src/nprintml/learn/automl.py
+++ b/src/nprintml/learn/automl.py
@@ -13,6 +13,8 @@ import itertools
 import matplotlib.pyplot as plt
 import seaborn as sns
 from autogluon.tabular import TabularPredictor
+from autogluon.features.generators import AutoMLPipelineFeatureGenerator
+from autogluon.core.features.feature_metadata import FeatureMetadata
 from sklearn.model_selection import train_test_split
 from sklearn.preprocessing import LabelBinarizer
 from sklearn.metrics import (
@@ -93,6 +95,16 @@ class AutoML:
         """Train prospective models."""
         # predictor gives us default access to the *best* predictor that
         # was trained on the task (otherwise we're just wrapping AutoGluon)
+        fg = AutoMLPipelineFeatureGenerator(enable_categorical_features=False,
+                                            enable_datetime_features=False,
+                                            enable_text_special_features=False,
+                                            enable_text_ngram_features=False
+                                           )
+        d = {}
+        for col in train_data.columns[:-1]:
+            d[col] = 'int'
+        fmd = FeatureMetadata(d)
+
         task = TabularPredictor(
             label='label',
             eval_metric=eval_metric,
@@ -103,6 +115,8 @@ class AutoML:
             train_data=train_data,
             time_limit=time_limit,
             presets=self.QUALITY_PRESETS[quality],
+            feature_generator=fg,
+            feature_metadata=fmd
         )
 
     def test(self, predictor, test_data):

--- a/src/nprintml/learn/automl.py
+++ b/src/nprintml/learn/automl.py
@@ -13,8 +13,8 @@ import itertools
 import matplotlib.pyplot as plt
 import seaborn as sns
 from autogluon.tabular import TabularPredictor
-from autogluon.features.generators import AutoMLPipelineFeatureGenerator
 from autogluon.core.features.feature_metadata import FeatureMetadata
+from autogluon.features.generators import AutoMLPipelineFeatureGenerator
 from sklearn.model_selection import train_test_split
 from sklearn.preprocessing import LabelBinarizer
 from sklearn.metrics import (
@@ -95,11 +95,17 @@ class AutoML:
         """Train prospective models."""
         # predictor gives us default access to the *best* predictor that
         # was trained on the task (otherwise we're just wrapping AutoGluon)
+
+        # create custom feature generator to force autogluon to use our features
+        # as they are
         fg = AutoMLPipelineFeatureGenerator(enable_categorical_features=False,
                                             enable_datetime_features=False,
                                             enable_text_special_features=False,
                                             enable_text_ngram_features=False
                                            )
+    
+        # create our own feature metadata object as we know what the type of every
+        # feature we have. Skip the label column in the training data when doing so
         d = {}
         for col in train_data.columns[:-1]:
             d[col] = 'int'


### PR DESCRIPTION
Does a few things

1. Create our own custom feature generator object which forces AutoGluon to use our features as is. This doesn't seem to save too much time as is, but with larger datasets this could help multiple passes of the features & (not sure how to test this) may save the memory that AutoGluon eats up when it creates multiple sets of features
2. Pass in the type of each feature as we're in the unique position that we know what each feature is.

Only question would be when we implement #34 if a user supplies a custom feature that is say, a float, we may have trouble. Should we check and see if we ran nPrint to create the dataframe before making these smaller optimizations?