### PR TITLE
support selection of features file format and default to Feather format

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -15,6 +15,7 @@ INSTALL_REQUIRES = [
     'numpy == 1.19.5',
 
     'pandas ~= 1.1.5',
+    'pyarrow ~= 4.0.0',
 
     'matplotlib ~= 3.3.4',
     'seaborn ~= 0.11.1',

--- a/src/nprintml/label/aggregator/pcap.py
+++ b/src/nprintml/label/aggregator/pcap.py
@@ -121,6 +121,12 @@ class PcapLabelAggregator(LabelAggregator):
         # now we can move it in place:
         npts.set_index(0, inplace=True)
 
+        # both columns and indices were ranges and as such the name of the
+        # index is currently set to the integer 0.
+        # for clarity and compatibility (e.g. with output to Feather) let's
+        # give the index its proper name:
+        npts.index.name = 'pcap'
+
         # npt lengths are unknown ahead of time; and, with flatten(), each becomes a row length.
         # luckily, we need not make them equal first -- pandas fills in na or None.
         # constructor doesn't allow specification of this missing sentinel;

--- a/test/cli_test/test_pcap.py
+++ b/test/cli_test/test_pcap.py
@@ -11,6 +11,10 @@ TEST_ROOT = pathlib.Path(__file__).parent.parent
 TEST_DATA = TEST_ROOT / 'data'
 
 
+def mktestdir(prefix=f'nprintml.{__name__}.'):
+    return tempfile.TemporaryDirectory(prefix=prefix)
+
+
 def testdir(func):
     """Decorator to wrap given function such that a temporary directory
     is created and destroyed for each invocation.
@@ -18,7 +22,7 @@ def testdir(func):
     """
     @functools.wraps(func)
     def wrapper(*args, **kwargs):
-        with tempfile.TemporaryDirectory(prefix=f'nprintml.{func.__module__}.') as tempdir:
+        with mktestdir() as tempdir:
             return func(*args, tempdir, **kwargs)
 
     return wrapper
@@ -44,8 +48,81 @@ class TestPcap(CLITestCase):
         npt_dir = temp_path / 'nprint'
         self.assertFalse(npt_dir.exists())
 
-        feature_path = temp_path / 'feature' / 'features.csv.gz'
+        feature_path = temp_path / 'feature' / 'features.fhr.zstd'
         self.assertTrue(feature_path.exists())
+
+        graphs_path = temp_path / 'model' / 'graphs'
+        self.assertTrue(any(graphs_path.glob('*.pdf')))
+
+        models_path = temp_path / 'model' / 'models'
+        self.assertTrue(any(models_path.rglob('*.pkl')))
+
+        meta_path = temp_path / 'meta.toml'
+        self.assertTrue(meta_path.exists())
+        self.assertEqual(toml.load(meta_path).get('nprint', {}).get('cmd'),
+                         'nprint --pcap_file [input_pcap] --ipv4 --tcp')
+
+    def test_pcap_file_write_features_selection(self):
+        for output_format in (
+            'csv', 'csv.gz',
+            'parquet.brotli', 'parquet.gzip', 'parquet.snappy',
+            'feather.lz4',
+        ):
+            with self.subTest(output_format=output_format):
+                with mktestdir() as tempdir:
+                    temp_path = pathlib.Path(tempdir)
+
+                    self.try_execute(
+                        '--save-features-format', output_format,
+                        '--tcp',
+                        '--ipv4',
+                        '--aggregator', 'index',
+                        '--label-file', TEST_DATA / 'single-pcap' / 'labels.txt',
+                        '--pcap-file', TEST_DATA / 'single-pcap' / 'test.pcap',
+                        '--output', temp_path,
+                        '--quiet',  # autogluon's threading makes capturing/suppressing
+                                    # its stdout a little harder
+                    )
+
+                    npt_dir = temp_path / 'nprint'
+                    self.assertFalse(npt_dir.exists())
+
+                    format_scheme = output_format.split('.')[-1]
+                    feature_path = temp_path / 'feature'
+                    self.assertTrue(any(feature_path.glob(f'features*.{format_scheme}')))
+
+                    graphs_path = temp_path / 'model' / 'graphs'
+                    self.assertTrue(any(graphs_path.glob('*.pdf')))
+
+                    models_path = temp_path / 'model' / 'models'
+                    self.assertTrue(any(models_path.rglob('*.pkl')))
+
+                    meta_path = temp_path / 'meta.toml'
+                    self.assertTrue(meta_path.exists())
+                    self.assertEqual(toml.load(meta_path).get('nprint', {}).get('cmd'),
+                                     'nprint --pcap_file [input_pcap] --ipv4 --tcp')
+
+    @testdir
+    def test_pcap_file_no_save_features(self, tempdir):
+        temp_path = pathlib.Path(tempdir)
+
+        self.try_execute(
+            '--no-save-features',
+            '--tcp',
+            '--ipv4',
+            '--aggregator', 'index',
+            '--label-file', TEST_DATA / 'single-pcap' / 'labels.txt',
+            '--pcap-file', TEST_DATA / 'single-pcap' / 'test.pcap',
+            '--output', temp_path,
+            '--quiet',  # autogluon's threading makes capturing/suppressing
+                        # its stdout a little harder
+        )
+
+        npt_dir = temp_path / 'nprint'
+        self.assertFalse(npt_dir.exists())
+
+        feature_path = temp_path / 'feature'
+        self.assertFalse(feature_path.exists())
 
         graphs_path = temp_path / 'model' / 'graphs'
         self.assertTrue(any(graphs_path.glob('*.pdf')))
@@ -77,7 +154,7 @@ class TestPcap(CLITestCase):
         npt_path = temp_path / 'nprint' / 'test.npt'
         self.assertTrue(npt_path.exists())
 
-        feature_path = temp_path / 'feature' / 'features.csv.gz'
+        feature_path = temp_path / 'feature' / 'features.fhr.zstd'
         self.assertTrue(feature_path.exists())
 
         graphs_path = temp_path / 'model' / 'graphs'
@@ -109,7 +186,7 @@ class TestPcap(CLITestCase):
         npt_dir = temp_path / 'nprint'
         self.assertFalse(npt_dir.exists())
 
-        feature_path = temp_path / 'feature' / 'features.csv.gz'
+        feature_path = temp_path / 'feature' / 'features.fhr.zstd'
         self.assertTrue(feature_path.exists())
 
         graphs_path = temp_path / 'model' / 'graphs'
@@ -149,7 +226,7 @@ class TestPcap(CLITestCase):
         npt_count = sum(1 for _npt_file in pathlib.Path(npt_path).rglob('*.npt'))
         self.assertEqual(npt_count, 202)
 
-        feature_path = temp_path / 'feature' / 'features.csv.gz'
+        feature_path = temp_path / 'feature' / 'features.fhr.zstd'
         self.assertTrue(feature_path.exists())
 
         graphs_path = temp_path / 'model' / 'graphs'
@@ -189,7 +266,7 @@ class TestPcap(CLITestCase):
         npt_count = sum(1 for _npt_file in pathlib.Path(npt_path).rglob('*.npt'))
         self.assertEqual(npt_count, 100)
 
-        feature_path = temp_path / 'feature' / 'features.csv.gz'
+        feature_path = temp_path / 'feature' / 'features.fhr.zstd'
         self.assertTrue(feature_path.exists())
 
         graphs_path = temp_path / 'model' / 'graphs'


### PR DESCRIPTION
User may now select from a variety of file formats (CSV, Parquet, Feather) and compression schemes (GZIP, Brotli, *etc*.) for storing the final features data on disk. The default is now Feather format with zstd compression.

See [comment on Issue 55](https://github.com/nprint/nprintML/issues/55#issuecomment-831474563) for discussion of these options.

(Further optimization via background queue is left to #61.)

Resolves #55.